### PR TITLE
Fix #18: Handle X.509 certificate (version 1 by default)

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -70,11 +70,11 @@ class RSAPKCSParser {
     }
   }
 
-  RSAPublicKey _pkcs8CertificatePrivateKey(ASN1Sequence seq) {
+  RSAPublicKey _pkcs8CertificatePublicKey(ASN1Sequence seq) {
     if (seq.elements.length != 3) _error('Bad certificate format');
     var certificate = seq.elements[0] as ASN1Sequence;
-
-    var subjectPublicKeyInfo = certificate.elements[6] as ASN1Sequence;
+    var publicKeyIndex = certificate.elements[0] is ASN1Integer /* No version info */ ? 5 : 6;
+    var subjectPublicKeyInfo = certificate.elements[publicKeyIndex] as ASN1Sequence;
 
     return _pkcs8PublicKey(subjectPublicKeyInfo);
   }
@@ -144,7 +144,7 @@ class RSAPKCSParser {
     if (lines[header] == pkcs1PublicHeader) {
       return _pkcs1PublicKey(seq);
     } else if (lines[header] == certHeader) {
-      return _pkcs8CertificatePrivateKey(seq);
+      return _pkcs8CertificatePublicKey(seq);
     } else {
       return _pkcs8PublicKey(seq);
     }


### PR DESCRIPTION
See https://github.com/Ephenodrom/Dart-Basic-Utils/issues/11 and https://security.stackexchange.com/q/136164

Here is an example of X.509 version 1 certificate:
```
-----BEGIN CERTIFICATE-----
MIICizCCAfQCCQCY8tKaMc0BMjANBgkqhkiG9w0BAQUFADCBiTELMAkGA1UEBhMC
Tk8xEjAQBgNVBAgTCVRyb25kaGVpbTEQMA4GA1UEChMHVU5JTkVUVDEOMAwGA1UE
CxMFRmVpZGUxGTAXBgNVBAMTEG9wZW5pZHAuZmVpZGUubm8xKTAnBgkqhkiG9w0B
CQEWGmFuZHJlYXMuc29sYmVyZ0B1bmluZXR0Lm5vMB4XDTA4MDUwODA5MjI0OFoX
DTM1MDkyMzA5MjI0OFowgYkxCzAJBgNVBAYTAk5PMRIwEAYDVQQIEwlUcm9uZGhl
aW0xEDAOBgNVBAoTB1VOSU5FVFQxDjAMBgNVBAsTBUZlaWRlMRkwFwYDVQQDExBv
cGVuaWRwLmZlaWRlLm5vMSkwJwYJKoZIhvcNAQkBFhphbmRyZWFzLnNvbGJlcmdA
dW5pbmV0dC5ubzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAt8jLoqI1VTlx
AZ2axiDIThWcAOXdu8KkVUWaN/SooO9O0QQ7KRUjSGKN9JK65AFRDXQkWPAu4Hln
O4noYlFSLnYyDxI66LCr71x4lgFJjqLeAvB/GqBqFfIZ3YK/NrhnUqFwZu63nLrZ
jcUZxNaPjOOSRSDaXpv1kb5k3jOiSGECAwEAATANBgkqhkiG9w0BAQUFAAOBgQBQ
Yj4cAafWaYfjBU2zi1ElwStIaJ5nyp/s/8B8SAPK2T79McMyccP3wSW13LHkmM1j
wKe3ACFXBvqGQN0IbcH49hu0FKhYFM/GPDJcIHFBsiyMBXChpye9vBaTNEBCtU3K
jjyG0hRT2mAQ9h+bkPmOvlEo/aH0xR68Z9hw4PF13w==
-----END CERTIFICATE-----
```