### PR TITLE
Fix lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+* Fix null safety lint warnings.
+
 ## 2.0.1
 
 * Handle X.509 certificates version 3 (version 1 is default)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,10 +12,8 @@ linter:
   - always_declare_return_types
   - always_put_control_body_on_new_line
   - always_put_required_named_parameters_first
-  - always_require_non_null_named_parameters
   - always_specify_types
   - annotate_overrides
-  - avoid_as
   - avoid_bool_literals_in_conditional_expressions
   - avoid_catches_without_on_clauses
   - avoid_double_and_int_checks
@@ -30,7 +28,6 @@ linter:
   - avoid_relative_lib_imports
   - avoid_renaming_method_parameters
   - avoid_return_types_on_setters
-  - avoid_returning_null
   - avoid_single_cascade_in_expression_statements
   - avoid_slow_async_io
   - avoid_types_as_parameter_names
@@ -50,11 +47,10 @@ linter:
   - hash_and_equals
   - implementation_imports
   - invariant_booleans
-  - iterable_contains_unrelated_type
   - join_return_with_assignment
   - library_names
   - library_prefixes
-  - list_remove_unrelated_type
+  - collection_methods_unrelated_type
   - literal_only_boolean_expressions
   - no_adjacent_strings_in_list
   - no_duplicate_case_values

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -71,10 +71,12 @@ class RSAPKCSParser {
   }
 
   RSAPublicKey _pkcs8CertificatePublicKey(ASN1Sequence seq) {
-    if (seq.elements.length != 3) _error('Bad certificate format');
-    var certificate = seq.elements[0] as ASN1Sequence;
-    var publicKeyIndex = certificate.elements[0] is ASN1Integer /* No version info */ ? 5 : 6;
-    var subjectPublicKeyInfo = certificate.elements[publicKeyIndex] as ASN1Sequence;
+    if (seq.elements.length != 3) {
+      _error('Bad certificate format');
+    }
+    final ASN1Sequence certificate = seq.elements[0] as ASN1Sequence;
+    final int publicKeyIndex = certificate.elements[0] is ASN1Integer /* No version info */ ? 5 : 6;
+    final ASN1Sequence subjectPublicKeyInfo = certificate.elements[publicKeyIndex] as ASN1Sequence;
 
     return _pkcs8PublicKey(subjectPublicKeyInfo);
   }
@@ -107,9 +109,9 @@ class RSAPKCSParser {
 
   RSAPrivateKey _pkcs1PrivateKey(ASN1Sequence seq) {
     final List<ASN1Integer> asn1Ints = seq.elements.cast<ASN1Integer>();
-    return RSAPrivateKey(asn1Ints[0].intValue, asn1Ints[1].valueAsBigInteger!, asn1Ints[2].intValue, asn1Ints[3].valueAsBigInteger!,
-     asn1Ints[4].valueAsBigInteger!, asn1Ints[5].valueAsBigInteger!, asn1Ints[6].valueAsBigInteger!, asn1Ints[7].valueAsBigInteger!,
-     asn1Ints[8].valueAsBigInteger!);
+    return RSAPrivateKey(asn1Ints[0].intValue, asn1Ints[1].valueAsBigInteger, asn1Ints[2].intValue, asn1Ints[3].valueAsBigInteger,
+     asn1Ints[4].valueAsBigInteger, asn1Ints[5].valueAsBigInteger, asn1Ints[6].valueAsBigInteger, asn1Ints[7].valueAsBigInteger,
+     asn1Ints[8].valueAsBigInteger);
   }
 
   RSAPrivateKey _pkcs8PrivateKey(ASN1Sequence seq) {
@@ -152,7 +154,7 @@ class RSAPKCSParser {
 
   RSAPublicKey _pkcs1PublicKey(ASN1Sequence seq) {
     final List<ASN1Integer> asn1Ints = seq.elements.cast<ASN1Integer>();
-    return RSAPublicKey(asn1Ints[0].valueAsBigInteger!, asn1Ints[1].intValue);
+    return RSAPublicKey(asn1Ints[0].valueAsBigInteger, asn1Ints[1].intValue);
   }
 
   RSAPublicKey _pkcs8PublicKey(ASN1Sequence seq) {
@@ -191,6 +193,9 @@ class RSAPublicKey {
 
 /// Private key
 class RSAPrivateKey {
+
+  RSAPrivateKey(this.version, this.modulus, this.publicExponent, this.privateExponent, this.prime1, this.prime2, this.exponent1, this.exponent2, this.coefficient);
+  
   /// Version
   int version;
 
@@ -217,8 +222,6 @@ class RSAPrivateKey {
 
   /// Coefficient
   BigInt coefficient;
-
-  RSAPrivateKey(this.version, this.modulus, this.publicExponent, this.privateExponent, this.prime1, this.prime2, this.exponent1, this.exponent2, this.coefficient);
 }
 
 class X509Certificate {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rsa_pkcs
-version: 2.0.1
+version: 2.0.2
 description: Privacy-Enhanced Mail (PEM) parser, RSA, PKCS#1, PKCS#8, X.509
 homepage: https://github.com/amaurel/rsa_pkcs
 repository: https://github.com/amaurel/rsa_pkcs

--- a/test/rsa_pkcs_test.dart
+++ b/test/rsa_pkcs_test.dart
@@ -1,17 +1,18 @@
 library rsa_pkcs_test;
 
 import 'dart:io';
-import 'package:test/test.dart';
+
 import 'package:rsa_pkcs/rsa_pkcs.dart';
+import 'package:test/test.dart';
 
 /// Test suite
 void main() {
   test('X509 certificate', () {
-    final certificateFile = File('test/resource/certificate.pem');
-    final pem = certificateFile.readAsStringSync();
+    final File certificateFile = File('test/resource/certificate.pem');
+    final String pem = certificateFile.readAsStringSync();
 
-    final parser = RSAPKCSParser();
-    final pair = parser.parsePEM(pem);
+    final RSAPKCSParser parser = RSAPKCSParser();
+    final RSAKeyPair pair = parser.parsePEM(pem);
 
     expect(pair.private, isNull);
     expect(pair.public, isNotNull);
@@ -27,11 +28,11 @@ void main() {
   test('rsa private key PKCS#1', () {
     //openssl genrsa -out rsa_private_key.pem
     //
-    final rsaPrivateKeyFile = File('test/resource/rsa_private_key.pem');
-    final pem = rsaPrivateKeyFile.readAsStringSync();
-    final parser = RSAPKCSParser();
-    final pair = parser.parsePEM(pem);
-    final privateKey = pair.private;
+    final File rsaPrivateKeyFile = File('test/resource/rsa_private_key.pem');
+    final String pem = rsaPrivateKeyFile.readAsStringSync();
+    final RSAPKCSParser parser = RSAPKCSParser();
+    final RSAKeyPair pair = parser.parsePEM(pem);
+    final RSAPrivateKey? privateKey = pair.private;
 
     expect(pair.public, equals(null));
     expect(privateKey!, isNotNull);
@@ -85,7 +86,6 @@ void main() {
     final RSAPublicKey publicKey = pair.public!;
 
     expect(privateKey, equals(null));
-    expect(publicKey != null, equals(true));
 
     expect(
         publicKey.modulus,


### PR DESCRIPTION
This PR fixes the lint warnings that appear on the terminal when running a program that depends on `rsa_pkcs`.
These are the warnings that the user sees:

![image](https://github.com/amaurel/rsa_pkcs/assets/22084723/46ed27b6-112c-4f9a-b06b-6af95a253be2)
